### PR TITLE
fix: spy on an instance and not a prototype

### DIFF
--- a/src/spyOn.ts
+++ b/src/spyOn.ts
@@ -110,11 +110,7 @@ export function spyOn<T, K extends string & keyof T>(
       delete desc.writable // getter/setter can't have writable attribute at all
     }
     ;(desc as PropertyDescriptor)[accessType] = cb
-    Object.defineProperty(
-      objDescriptor || !descriptor ? obj : proto,
-      accessName,
-      desc
-    )
+    Object.defineProperty(obj, accessName, desc)
   }
   let restore = () => define(origin)
   fn.restore = restore

--- a/test/class.test.ts
+++ b/test/class.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest'
+import { spyOn } from '../src'
+
+class Dep {
+  run(): boolean {
+    return false
+  }
+}
+
+describe('class mock', () => {
+  let dep1: Dep
+  let dep2: Dep
+
+  test('works with multiple instances', () => {
+    dep1 = new Dep()
+    const spy1 = spyOn(dep1, 'run')
+
+    dep2 = new Dep()
+    const spy2 = spyOn(dep2, 'run')
+
+    dep1.run()
+    dep2.run()
+
+    expect(spy1.callCount).toBe(1)
+    expect(spy2.callCount).toBe(1)
+  })
+})


### PR DESCRIPTION
tinyspy mocks object prototype instead of instance.  
This works with nanospy

Related vitest issue: https://github.com/vitest-dev/vitest/issues/645